### PR TITLE
iptables-save 保存防火墙规则时-m webstr --url会漏一个空格

### DIFF
--- a/trunk/user/iptables/iptables-1.4.16.3/extensions/libxt_webstr.c
+++ b/trunk/user/iptables/iptables-1.4.16.3/extensions/libxt_webstr.c
@@ -173,7 +173,7 @@ webstr_save(const void *ip, const struct xt_entry_match *match)
 {
 	struct xt_webstr_info *stringinfo = (struct xt_webstr_info *)match->data;
 
-	printf("--"); print_type(stringinfo->type);
+	printf(" --"); print_type(stringinfo->type);
 	print_string(stringinfo->string, stringinfo->invert, 0);
 }
 


### PR DESCRIPTION
iptables-save 保存防火墙规则时-m webstr --url会漏一个空格
libxt_webstr.c改为
printf(" --"); print_type(stringinfo->type);